### PR TITLE
feat: add platform field to social media link and update speaker profile doctype

### DIFF
--- a/buzz/events/doctype/social_media_link/social_media_link.json
+++ b/buzz/events/doctype/social_media_link/social_media_link.json
@@ -6,6 +6,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "platform",
   "url"
  ],
  "fields": [
@@ -16,13 +17,20 @@
    "label": "URL",
    "options": "URL",
    "reqd": 1
+  },
+  {
+   "fieldname": "platform",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Platform",
+   "options": "\nInstagram\nTwitter / X\nLinkedIn\nGithub\nFacebook\nTikTok\nYouTube\nWebsite"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-19 12:38:48.912298",
+ "modified": "2025-10-02 17:02:01.506197",
  "modified_by": "Administrator",
  "module": "Events",
  "name": "Social Media Link",

--- a/buzz/events/doctype/social_media_link/social_media_link.py
+++ b/buzz/events/doctype/social_media_link/social_media_link.py
@@ -6,4 +6,18 @@ from frappe.model.document import Document
 
 
 class SocialMediaLink(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		platform: DF.Literal["", "Instagram", "Twitter / X", "LinkedIn", "Github", "Facebook", "TikTok", "YouTube", "Website"]
+		url: DF.Data
+	# end: auto-generated types
 	pass

--- a/buzz/events/doctype/speaker_profile/speaker_profile.json
+++ b/buzz/events/doctype/speaker_profile/speaker_profile.json
@@ -1,13 +1,12 @@
 {
  "actions": [],
- "allow_rename": 1,
  "autoname": "autoincrement",
  "creation": "2025-07-19 11:58:20.573125",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "user",
   "display_name",
+  "full_name",
   "column_break_dbuw",
   "display_image",
   "section_break_kmlw",
@@ -19,24 +18,17 @@
  ],
  "fields": [
   {
-   "fieldname": "user",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "User",
-   "options": "User",
-   "reqd": 1
-  },
-  {
    "fieldname": "column_break_dbuw",
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "user.full_name",
    "fieldname": "display_name",
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Display Name"
+   "label": "Email",
+   "options": "Email",
+   "reqd": 1
   },
   {
    "fieldname": "designation",
@@ -72,13 +64,20 @@
    "fieldtype": "Table",
    "label": "Social Media Links",
    "options": "Social Media Link"
+  },
+  {
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Full Name",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
  "image_field": "display_image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-09-25 19:03:36.807212",
+ "modified": "2025-10-02 13:14:49.536365",
  "modified_by": "Administrator",
  "module": "Events",
  "name": "Speaker Profile",
@@ -116,5 +115,5 @@
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
- "title_field": "display_name"
+ "title_field": "full_name"
 }

--- a/buzz/events/doctype/speaker_profile/speaker_profile.py
+++ b/buzz/events/doctype/speaker_profile/speaker_profile.py
@@ -12,17 +12,16 @@ class SpeakerProfile(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from frappe.types import DF
-
 		from buzz.events.doctype.social_media_link.social_media_link import SocialMediaLink
+		from frappe.types import DF
 
 		company: DF.Data | None
 		designation: DF.Data | None
 		display_image: DF.AttachImage | None
-		display_name: DF.Data | None
+		display_name: DF.Data
+		full_name: DF.Data
 		name: DF.Int | None
 		social_media_links: DF.Table[SocialMediaLink]
-		user: DF.Link
 	# end: auto-generated types
 
 	pass


### PR DESCRIPTION
This pull request updates the schema and type definitions for the `Speaker Profile` and `Social Media Link` doctypes to improve data structure and type safety. The most significant changes involve restructuring fields in `Speaker Profile`, introducing a new `platform` field in `Social Media Link`, and updating the corresponding Python type hints.

**Speaker Profile Doctype Changes:**

* Removed the `user` field and replaced it with separate `full_name` and `display_name` fields; `full_name` is now required and used as the title field, while `display_name` is now labeled as "Email" and also required. (`buzz/events/doctype/speaker_profile/speaker_profile.json` [[1]](diffhunk://#diff-471592b0ce0e7c0fb12cdddc1994785ff90602c6a93a838b626666504eb37a05L3-R9) [[2]](diffhunk://#diff-471592b0ce0e7c0fb12cdddc1994785ff90602c6a93a838b626666504eb37a05L21-R31) [[3]](diffhunk://#diff-471592b0ce0e7c0fb12cdddc1994785ff90602c6a93a838b626666504eb37a05R67-R80) [[4]](diffhunk://#diff-471592b0ce0e7c0fb12cdddc1994785ff90602c6a93a838b626666504eb37a05L119-R118)
* Updated the auto-generated type hints in `SpeakerProfile` to remove `user` and add `full_name` and adjust types accordingly. (`buzz/events/doctype/speaker_profile/speaker_profile.py` [buzz/events/doctype/speaker_profile/speaker_profile.pyL15-L25](diffhunk://#diff-ded34c443161a3525425c25aa70633a175269a18e4b4f2703c557f4a8c6a0662L15-L25))

**Social Media Link Doctype Changes:**

* Added a new required `platform` field (select type) with options for various social networks, and updated the field order to include it. (`buzz/events/doctype/social_media_link/social_media_link.json` [[1]](diffhunk://#diff-b5c826c5663f43575486250c8fe7c5d02e898ec8ee262e111700e2cfe63f80c3R9) [[2]](diffhunk://#diff-b5c826c5663f43575486250c8fe7c5d02e898ec8ee262e111700e2cfe63f80c3R20-R33)
* Updated the auto-generated type hints in `SocialMediaLink` to include the new `platform` field with a restricted set of allowed values. (`buzz/events/doctype/social_media_link/social_media_link.py` [buzz/events/doctype/social_media_link/social_media_link.pyR9-R22](diffhunk://#diff-717cb05bf3c36616eed6b27eb4889f5b7b9b1f7db77cc59d02fe4594911492f6R9-R22))