### PR TITLE
feat: Add mode of payment handling for event bookings

### DIFF
--- a/buzz/events/doctype/fe_event/fe_event.json
+++ b/buzz/events/doctype/fe_event/fe_event.json
@@ -15,6 +15,7 @@
   "host",
   "venue",
   "is_ticketed",
+  "mode_of_payment",
   "section_break_naqe",
   "start_date",
   "start_time",
@@ -254,6 +255,12 @@
    "label": "Company",
    "options": "Company",
    "reqd": 1
+  },
+  {
+   "fieldname": "mode_of_payment",
+   "fieldtype": "Link",
+   "label": "Mode of Payment",
+   "options": "Mode of Payment"
   }
  ],
  "grid_page_length": 50,
@@ -326,7 +333,7 @@
    "link_fieldname": "event"
   }
  ],
- "modified": "2025-10-07 16:00:31.609416",
+ "modified": "2025-10-08 15:50:42.195459",
  "modified_by": "Administrator",
  "module": "Events",
  "name": "FE Event",

--- a/buzz/events/doctype/fe_event/fe_event.py
+++ b/buzz/events/doctype/fe_event/fe_event.py
@@ -29,6 +29,7 @@ class FEEvent(Document):
 		is_published: DF.Check
 		is_ticketed: DF.Check
 		medium: DF.Literal["In Person", "Online"]
+		mode_of_payment: DF.Link | None
 		name: DF.Int | None
 		payment_gateway: DF.Link | None
 		registration_url: DF.Data | None

--- a/buzz/ticketing/doctype/event_booking/event_booking.js
+++ b/buzz/ticketing/doctype/event_booking/event_booking.js
@@ -11,6 +11,8 @@ frappe.ui.form.on("Event Booking", {
 			};
 		});
 
+		// set_mop(frm);
+
 		if (!frm.is_new()) {
 			frm.add_custom_button("Request Payment", () => {
 				frappe.prompt(
@@ -55,4 +57,17 @@ frappe.ui.form.on("Event Booking", {
 				});
 			});
 	},
+
+	event(frm) {
+		// set_mop(frm);
+	},
 });
+
+function set_mop(frm) {
+	if (!frm.doc.event || frm.doc.mode_of_payment) return;
+	frappe.db.get_value("FE Event", frm.doc.event, "mode_of_payment").then((r) => {
+		if (r.message && r.message.mode_of_payment) {
+			frm.set_value("mode_of_payment", r.message.mode_of_payment);
+		}
+	});
+}

--- a/buzz/ticketing/doctype/event_booking/event_booking.py
+++ b/buzz/ticketing/doctype/event_booking/event_booking.py
@@ -41,12 +41,17 @@ class EventBooking(Document):
     # end: auto-generated types
 
     def validate(self):
+        self.set_mpo()
         self.validate_ticket_availability()
         self.fetch_amounts_from_ticket_types()
         self.set_currency()
         self.set_total()
         self.apply_taxes_if_applicable()
         self.customer = self.make_customer()
+
+    def set_mpo(self):
+        event = frappe.get_doc("FE Event", self.event)
+        self.mode_of_payment = event.mode_of_payment
 
     def set_currency(self):
         self.currency = self.attendees[0].currency


### PR DESCRIPTION
Introduces mode of payment field in FE Event and propagates it to Event Bookings

- Adds mode_of_payment field to FE Event doctype
- Implements automatic sync of payment mode from event to booking
- Adds server-side validation to ensure payment mode is set
- Includes commented client-side sync implementation for future use