### PR TITLE
Add ticket type and capacity fields to Event Ticket Type DocType

### DIFF
--- a/buzz/ticketing/doctype/event_ticket_type/event_ticket_type.json
+++ b/buzz/ticketing/doctype/event_ticket_type/event_ticket_type.json
@@ -1,178 +1,198 @@
 {
-  "actions": [],
-  "autoname": "autoincrement",
-  "creation": "2025-07-22 19:49:59.242064",
-  "doctype": "DocType",
-  "engine": "InnoDB",
-  "field_order": [
-    "title",
-    "price",
-    "currency",
-    "linked_item",
-    "column_break_lrao",
-    "event",
-    "company",
-    "is_published",
-    "auto_unpublish_after",
-    "max_tickets_available",
-    "stats_section",
-    "tickets_sold",
-    "column_break_ygut",
-    "remaining_tickets"
-  ],
-  "fields": [
-    {
-      "fieldname": "event",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Event",
-      "options": "Buzz Event",
-      "reqd": 1
-    },
-    {
-      "description": "VIP, Early Bird, etc.",
-      "fieldname": "title",
-      "fieldtype": "Data",
-      "label": "Title",
-      "reqd": 1
-    },
-    {
-      "fieldname": "column_break_lrao",
-      "fieldtype": "Column Break"
-    },
-    {
-      "allow_in_quick_entry": 1,
-      "default": "0",
-      "fieldname": "price",
-      "fieldtype": "Currency",
-      "label": "Price",
-      "non_negative": 1,
-      "options": "currency"
-    },
-    {
-      "fieldname": "currency",
-      "fieldtype": "Link",
-      "label": "Currency",
-      "options": "Currency",
-      "reqd": 1
-    },
-    {
-      "default": "1",
-      "fieldname": "is_published",
-      "fieldtype": "Check",
-      "label": "Is Published?"
-    },
-    {
-      "description": "Leave it 0 for no limit",
-      "fieldname": "max_tickets_available",
-      "fieldtype": "Int",
-      "label": "Max Tickets Available",
-      "non_negative": 1
-    },
-    {
-      "depends_on": "eval:doc.is_published",
-      "description": "For Early Bird, etc.",
-      "fieldname": "auto_unpublish_after",
-      "fieldtype": "Date",
-      "label": "Auto Unpublish After"
-    },
-    {
-      "fieldname": "stats_section",
-      "fieldtype": "Section Break",
-      "label": "Stats"
-    },
-    {
-      "description": "-1 if no limit defined above",
-      "fieldname": "remaining_tickets",
-      "fieldtype": "Int",
-      "is_virtual": 1,
-      "label": "Remaining Tickets"
-    },
-    {
-      "fieldname": "tickets_sold",
-      "fieldtype": "Int",
-      "is_virtual": 1,
-      "label": "Tickets Sold"
-    },
-    {
-      "fieldname": "column_break_ygut",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fetch_from": "event.company",
-      "fieldname": "company",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Company",
-      "read_only": 1,
-      "reqd": 1
-    },
-    {
-      "fieldname": "linked_item",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Linked Item",
-      "options": "Item"
-    }
-  ],
-  "grid_page_length": 50,
-  "index_web_pages_for_search": 1,
-  "links": [
-    {
-      "link_doctype": "Event Ticket",
-      "link_fieldname": "ticket_type"
-    }
-  ],
-  "modified": "2025-10-10 14:44:14.178061",
-  "modified_by": "Administrator",
-  "module": "Ticketing",
-  "name": "Event Ticket Type",
-  "naming_rule": "Autoincrement",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Event Manager",
-      "select": 1,
-      "share": 1,
-      "write": 1
-    },
-    {
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Buzz User",
-      "select": 1,
-      "share": 1
-    }
-  ],
-  "quick_entry": 1,
-  "row_format": "Dynamic",
-  "search_fields": "event,price,currency",
-  "show_title_field_in_link": 1,
-  "sort_field": "creation",
-  "sort_order": "DESC",
-  "states": [],
-  "title_field": "title"
+ "actions": [],
+ "autoname": "autoincrement",
+ "creation": "2025-07-22 19:49:59.242064",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "ticket_type",
+  "ticket_capacity",
+  "price",
+  "currency",
+  "linked_item",
+  "column_break_lrao",
+  "event",
+  "company",
+  "is_published",
+  "auto_unpublish_after",
+  "max_tickets_available",
+  "stats_section",
+  "tickets_sold",
+  "column_break_ygut",
+  "remaining_tickets"
+ ],
+ "fields": [
+  {
+   "fieldname": "event",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Event",
+   "options": "Buzz Event",
+   "reqd": 1
+  },
+  {
+   "description": "VIP, Early Bird, etc.",
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_lrao",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_in_quick_entry": 1,
+   "default": "0",
+   "fieldname": "price",
+   "fieldtype": "Currency",
+   "label": "Price",
+   "non_negative": 1,
+   "options": "currency"
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency",
+   "reqd": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "is_published",
+   "fieldtype": "Check",
+   "label": "Is Published?"
+  },
+  {
+   "description": "Leave it 0 for no limit",
+   "fieldname": "max_tickets_available",
+   "fieldtype": "Int",
+   "label": "Max Tickets Available",
+   "non_negative": 1
+  },
+  {
+   "depends_on": "eval:doc.is_published",
+   "description": "For Early Bird, etc.",
+   "fieldname": "auto_unpublish_after",
+   "fieldtype": "Date",
+   "label": "Auto Unpublish After"
+  },
+  {
+   "fieldname": "stats_section",
+   "fieldtype": "Section Break",
+   "label": "Stats"
+  },
+  {
+   "description": "-1 if no limit defined above",
+   "fieldname": "remaining_tickets",
+   "fieldtype": "Int",
+   "is_virtual": 1,
+   "label": "Remaining Tickets"
+  },
+  {
+   "fieldname": "tickets_sold",
+   "fieldtype": "Int",
+   "is_virtual": 1,
+   "label": "Tickets Sold"
+  },
+  {
+   "fieldname": "column_break_ygut",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "event.company",
+   "fieldname": "company",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Company",
+   "read_only": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "linked_item",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Linked Item",
+   "options": "Item"
+  },
+  {
+   "fieldname": "ticket_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Ticket Type",
+   "options": "\nIndividual\nGroup",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.ticket_type===\"Group\"",
+   "description": "How many individuals are included in one group ticket",
+   "fieldname": "ticket_capacity",
+   "fieldtype": "Int",
+   "label": "Ticket Capacity",
+   "mandatory_depends_on": "eval:doc.ticket_type===\"Group\"",
+   "non_negative": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [
+  {
+   "link_doctype": "Event Ticket",
+   "link_fieldname": "ticket_type"
+  }
+ ],
+ "modified": "2025-11-25 17:01:55.802791",
+ "modified_by": "Administrator",
+ "module": "Ticketing",
+ "name": "Event Ticket Type",
+ "naming_rule": "Autoincrement",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Event Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Buzz User",
+   "select": 1,
+   "share": 1
+  }
+ ],
+ "quick_entry": 1,
+ "row_format": "Dynamic",
+ "search_fields": "event,price,currency",
+ "show_title_field_in_link": 1,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title"
 }

--- a/buzz/ticketing/doctype/event_ticket_type/event_ticket_type.py
+++ b/buzz/ticketing/doctype/event_ticket_type/event_ticket_type.py
@@ -6,6 +6,27 @@ from frappe.model.document import Document
 
 
 class EventTicketType(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		auto_unpublish_after: DF.Date | None
+		company: DF.Data
+		currency: DF.Link
+		event: DF.Link
+		is_published: DF.Check
+		linked_item: DF.Link | None
+		max_tickets_available: DF.Int
+		name: DF.Int | None
+		price: DF.Currency
+		ticket_capacity: DF.Int
+		ticket_type: DF.Literal["", "Individual", "Group"]
+		title: DF.Data
+	# end: auto-generated types
     # begin: auto-generated types
     # This code is auto-generated. Do not modify anything in this block.
 


### PR DESCRIPTION
This pull request introduces enhancements to the event ticketing system, primarily adding support for different ticket types and associated capacities. The changes affect both the data model and type definitions to enable more flexible ticketing options.

**Event Ticket Type Model Enhancements:**

* Added new `ticket_type` field as a required select option, allowing tickets to be categorized as either "Individual" or "Group".
* Introduced the `ticket_capacity` field, which is only applicable when `ticket_type` is set to "Group", representing the number of individuals included in a group ticket.
* Updated the field order in the `event_ticket_type.json` to include the new fields for better organization.

**Type Definitions Update:**

* Expanded the type hints in `event_ticket_type.py` to include the new fields `ticket_type` and `ticket_capacity`, improving code safety and clarity.
